### PR TITLE
Fetching registry with shallow source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "sup"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dirs",
  "etc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sup"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["clearloop <udtrokia@gmail.com>"]
 edition = "2018"
 description = "Substrate package manager"

--- a/src/cmd/tag.rs
+++ b/src/cmd/tag.rs
@@ -11,6 +11,10 @@ pub fn exec(limit: usize, update: bool) -> Result<()> {
 
     // Get tags
     let mut tags = registry.tag()?;
+    if tags.len() == 0 {
+        registry.update()?;
+    }
+
     let last = if limit < tags.len() || limit < 1 {
         limit
     } else {


### PR DESCRIPTION
## Desc

The `sup tag` command can not print any tags if we haven't fetched the whole registry.