### PR TITLE
Check tag of target project from target registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "etc"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb57be5ba8ec7e3e604ac93858ae49d2b5842b6eaa72400a79ed68d4f97ded1d"
+checksum = "4f7935cc590ee512e8073c4fe82b85e056216324e65aed24459204e3f6d9f72e"
 
 [[package]]
 name = "getrandom"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "etc"
-version = "0.1.11"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b9682af9c2214e9041a408b1c53fdfd1e4e4503b66b868422f006d3df52354"
+checksum = "42edd4c7a89ae9c59214528e8ddf18da1f5e8ffd2a8aed02811e3fc1c8ccc1bc"
 
 [[package]]
 name = "getrandom"
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "sup"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "dirs",
  "etc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "etc"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42edd4c7a89ae9c59214528e8ddf18da1f5e8ffd2a8aed02811e3fc1c8ccc1bc"
+checksum = "bb57be5ba8ec7e3e604ac93858ae49d2b5842b6eaa72400a79ed68d4f97ded1d"
 
 [[package]]
 name = "getrandom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ path = "src/bin/sup.rs"
 # deps
 [dependencies]
 dirs = "3.0.1"
-etc = "0.1.14"
+etc = "0.1.15"
 structopt = "0.3.14"
 toml = "0.5.6"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sup"
-version = "0.2.8"
+version = "0.2.9"
 authors = ["clearloop <udtrokia@gmail.com>"]
 edition = "2018"
 description = "Substrate package manager"
@@ -26,7 +26,7 @@ path = "src/bin/sup.rs"
 # deps
 [dependencies]
 dirs = "3.0.1"
-etc = "0.1.11"
+etc = "0.1.14"
 structopt = "0.3.14"
 toml = "0.5.6"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ path = "src/bin/sup.rs"
 # deps
 [dependencies]
 dirs = "3.0.1"
-etc = "0.1.15"
+etc = "0.1.16"
 structopt = "0.3.14"
 toml = "0.5.6"
 

--- a/src/cmd/new.rs
+++ b/src/cmd/new.rs
@@ -61,7 +61,7 @@ pub fn rustup() -> Result<()> {
 }
 
 /// Exec command `new`
-pub fn exec(registry: Registry, target: PathBuf, skip: bool, mut tag: String) -> Result<()> {
+pub fn exec(mut registry: Registry, target: PathBuf, skip: bool, mut tag: String) -> Result<()> {
     if !skip {
         rustup()?;
     }
@@ -93,9 +93,16 @@ pub fn exec(registry: Registry, target: PathBuf, skip: bool, mut tag: String) ->
             "The registry {} at tag {} doesn't have node-template",
             &registry.config.node.registry, &tag
         );
+        println!("failed.");
+        return Ok(());
     }
 
     // Checkout back to the latest commit
     registry.checkout("master")?;
+    if has_tag {
+        registry.config.node.tag(&tag);
+    }
+    registry.config.gen(target)?;
+    println!("ok!");
     Ok(())
 }

--- a/src/cmd/update.rs
+++ b/src/cmd/update.rs
@@ -37,8 +37,8 @@ pub fn exec(mut registry: Registry, path: PathBuf, tag: Option<String>) -> Resul
         if Etc::from(&registry.dir).find("node-template").is_err() {
             println!(
                 "Registry {} with tag {:?} doesn't have node-template, \
-                 update {:?} failed, please retry with `--update` flag",
-                &registry.config.node.registry, &tag, &path
+                 please retry with `--update` flag",
+                &registry.config.node.registry, &tag,
             );
             println!("failed.");
             return Ok(());

--- a/src/cmd/update.rs
+++ b/src/cmd/update.rs
@@ -1,13 +1,13 @@
 //! Comamnd Update
-
 use crate::{
     registry::{redep, Registry},
     result::Result,
 };
+use etc::{Etc, FileSystem};
 use std::path::PathBuf;
 
 /// Exec command `switch`
-pub fn exec(registry: Registry, path: PathBuf, tag: Option<String>) -> Result<()> {
+pub fn exec(mut registry: Registry, path: PathBuf, tag: Option<String>) -> Result<()> {
     let mut tags = registry.tag()?;
     if tags.is_empty() {
         println!("Fetching registry...");
@@ -18,7 +18,7 @@ pub fn exec(registry: Registry, path: PathBuf, tag: Option<String>) -> Result<()
     if let Some(ref tag) = tag {
         if !tags.contains(&tag) {
             println!(
-                "Doesn't have tag {} in registry, retry with `--update` flag",
+                "Doesn't have tag {} in registry, please retry with `--update` flag",
                 &tag
             );
             return Ok(());
@@ -31,20 +31,49 @@ pub fn exec(registry: Registry, path: PathBuf, tag: Option<String>) -> Result<()
                 &path.to_str().unwrap_or(".")
             );
         }
+
+        registry.config.node.tag(tag);
     } else {
-        println!(
-            "Use the latest registry without tags for {}",
-            path.to_str().unwrap_or(".")
-        );
+        if Etc::from(&registry.dir).find("node-template").is_err() {
+            println!(
+                "Registry {} with tag {:?} doesn't have node-template, \
+                 update {:?} failed, please retry with `--update` flag",
+                &registry.config.node.registry, &tag, &path
+            );
+            println!("failed.");
+            return Ok(());
+        }
+
+        // If has tag field in current `.sup.toml`
+        if let Some(ref tag) = registry.config.node.tag {
+            // Checkout to the target tag
+            if registry.checkout(&tag).is_err() {
+                println!(
+                    "Doesn't have tag {} in registry, please retry with `--update` flag",
+                    &tag
+                );
+                println!("failed.");
+                return Ok(());
+            }
+
+            println!("Update {} with tag {}", path.to_str().unwrap_or("."), &tag);
+        } else {
+            println!(
+                "Use the latest registry without tag for {}",
+                path.to_str().unwrap_or(".")
+            );
+        }
     }
 
     // Operate tags
-    etc::find_all(path, "Cargo.toml")?
+    etc::find_all(&path, "Cargo.toml")?
         .iter()
         .map(|ct| redep(&ct, &registry))
         .collect::<Result<Vec<_>>>()?;
 
     // Checkout back to the latest commit
     registry.checkout("master")?;
+    registry.config.gen(path)?;
+    println!("ok!");
     Ok(())
 }

--- a/src/cmd/update.rs
+++ b/src/cmd/update.rs
@@ -15,7 +15,7 @@ pub fn exec(registry: Registry, path: PathBuf, tag: Option<String>) -> Result<()
         tags = registry.tag()?;
     }
 
-    if let Some(tag) = tag {
+    if let Some(ref tag) = tag {
         if !tags.contains(&tag) {
             println!(
                 "Doesn't have tag {} in registry, retry with `--update` flag",
@@ -39,10 +39,10 @@ pub fn exec(registry: Registry, path: PathBuf, tag: Option<String>) -> Result<()
     }
 
     // Operate tags
-    let crates = etc::find_all(path, "Cargo.toml")?;
-    for ct in crates {
-        redep(&ct, &registry)?;
-    }
+    etc::find_all(path, "Cargo.toml")?
+        .iter()
+        .map(|ct| redep(&ct, &registry))
+        .collect::<Result<Vec<_>>>()?;
 
     // Checkout back to the latest commit
     registry.checkout("master")?;


### PR DESCRIPTION
## Desc

`Sup` will Generate a `.sup.toml` for projects, which is a local config against to `~/sup/config.toml`, it has a `tag` field for protecting the project from updating with invalid registry.

ref https://github.com/w3f/Grant-Milestone-Delivery/pull/48